### PR TITLE
#1063469 Add compatibility with Redmine 6.1

### DIFF
--- a/app/views/settings/_default_assign.erb
+++ b/app/views/settings/_default_assign.erb
@@ -19,9 +19,7 @@
                    unless selected.blank?
                    Integer(selected)
                    end
-                   ),
-                   :multiple => false,
-                   :size => 5)
+                   ))
       %>
     <% else %>
       <%= link_to(l(:default_assign_missing_users),

--- a/init.rb
+++ b/init.rb
@@ -1,42 +1,28 @@
 require 'redmine'
 
-# Including dispatcher.rb in case of Rails 2.x
-require 'dispatcher' unless Rails::VERSION::MAJOR >= 3
-
 require './plugins/redmine_default_assign/lib/default_assign_issue_patch'
 require './plugins/redmine_default_assign/lib/default_assign_project_patch'
 require './plugins/redmine_default_assign/lib/default_assign/hooks/default_assign_projects_hooks'
 require './plugins/redmine_default_assign/lib/default_assign/hooks/default_assign_issues_hooks'
 
-if Rails::VERSION::MAJOR >= 3
-  register_after_redmine_initialize_proc =
-    if Redmine::VERSION::MAJOR >= 5
-      Rails.application.config.public_method(:after_initialize)
-    else
-      reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
-      reloader.public_method(:to_prepare)
-    end
-  register_after_redmine_initialize_proc.call do
-    require_dependency 'project'
-    require_dependency 'issue'
-    Project.send(:include, DefaultAssignProjectPatch)
-    Issue.send(:include, DefaultAssignIssuePatch)
+register_after_redmine_initialize_proc =
+  if Redmine::VERSION::MAJOR >= 5
+    Rails.application.config.public_method(:after_initialize)
+  else
+    reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
+    reloader.public_method(:to_prepare)
   end
-else
-  Dispatcher.to_prepare do
-    require_dependency 'project'
-    require_dependency 'issue'
-    Project.send(:include, DefaultAssignProjectPatch)
-    Issue.send(:include, DefaultAssignIssuePatch)
-  end
+register_after_redmine_initialize_proc.call do
+  Project.send(:include, DefaultAssignProjectPatch)
+  Issue.send(:include, DefaultAssignIssuePatch)
 end
 
 Redmine::Plugin.register :redmine_default_assign do
   name 'Default Assign plugin'
-  author 'Robert Chady / Paul Dann'
+  author 'Robert Chady / Paul Dann | Southbridge'
   author_url 'https://github.com/giddie/redmine_default_assign'
   description 'Plugin implementing Douglas Campos\' ticket-482 code as a plugin.  It has since been extended to offer other features as well.'
-  version '0.6'
+  version '0.7.0'
 
   settings :default => {'default_assignee_id' => nil,
                         'interactive_assignment' => true,

--- a/lib/default_assign_issue_patch.rb
+++ b/lib/default_assign_issue_patch.rb
@@ -6,8 +6,6 @@ module DefaultAssignIssuePatch
 
     # Same as typing in the class
     base.class_eval do
-      unloadable
-
       before_create :assign_default_assignee
     end
   end

--- a/lib/default_assign_project_patch.rb
+++ b/lib/default_assign_project_patch.rb
@@ -4,8 +4,6 @@ module DefaultAssignProjectPatch
     base.send(:include, InstanceMethods)
 
     base.class_eval do
-      unloadable
-
       safe_attributes :default_assignee_id
       belongs_to :default_assignee, :class_name => "Principal"
       before_create :set_default_assignee


### PR DESCRIPTION
https://factory.southbridge.io/issues/1063469

- Add support Redmine 6.1
- Add support Ruby 3.3, Rails 7.2
- Drop support Rails 2.x
- Fix the dropdown of default user for new project on the Setting page